### PR TITLE
Deprecate dump

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -127,7 +127,7 @@ abstract class Base extends AbstractLogger
     /**
      * Dump to log a variable (by example an array)
      *
-     * @deprecated in v2.2.0
+     * @deprecated in v2.2.0, will be removed in v3.0.0
      * @param mixed $variable
      */
     public function dump($variable)

--- a/src/Base.php
+++ b/src/Base.php
@@ -55,7 +55,7 @@ abstract class Base extends AbstractLogger
      * @access public
      * @param  string  $level
      */
-    public function setLevel(string $level)
+    public function setLevel($level)
     {
         $this->level = $level;
     }

--- a/src/Base.php
+++ b/src/Base.php
@@ -132,6 +132,7 @@ abstract class Base extends AbstractLogger
      */
     public function dump($variable)
     {
+        trigger_error(sprintf('%s is deprecated', __METHOD__), E_USER_DEPRECATED);
         $this->log(LogLevel::DEBUG, var_export($variable, true));
     }
 

--- a/src/Base.php
+++ b/src/Base.php
@@ -55,7 +55,7 @@ abstract class Base extends AbstractLogger
      * @access public
      * @param  string  $level
      */
-    public function setLevel($level)
+    public function setLevel(string $level)
     {
         $this->level = $level;
     }

--- a/src/Base.php
+++ b/src/Base.php
@@ -127,6 +127,7 @@ abstract class Base extends AbstractLogger
     /**
      * Dump to log a variable (by example an array)
      *
+     * @deprecated in v2.2.0
      * @param mixed $variable
      */
     public function dump($variable)


### PR DESCRIPTION
This was an untested holdover from the initial fork, which is not part of the logger interface and therefore isn't especially usable.