### PR TITLE
Support `psr/log:^2.0`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,9 +53,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.json') }}-${{ matrix.php }}-${{ matrix.dep-version }}-${{ matrix.psr-log-version }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.php }}-${{ matrix.dep-version }}-php-
+            ${{ runner.os }}-php-${{ hashFiles('**/composer.json') }}-${{ matrix.php }}-${{ matrix.dep-version }}
+            ${{ runner.os }}-php-${{ hashFiles('**/composer.json') }}-${{ matrix.php }}
+            ${{ runner.os }}-php-${{ hashFiles('**/composer.json') }}
 
       - name: Install dependencies
         run: composer update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,15 @@ jobs:
         psr-log-version:
           - '1.0'
           - '2.0'
+        exclude:
+          # psr/log:2.0 needs PHP8
+          - php: '7.2'
+            psr-log-version: '2.0'
+          - php: '7.3'
+            psr-log-version: '2.0'
+          - php: '7.4'
+            psr-log-version: '2.0'
+
 
     steps:
       - name: Check out code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
           - '7.3'
           - '7.4'
           - '8.0'
+        psr-log-version:
+          - '1.0'
+          - '2.0'
 
     steps:
       - name: Check out code
@@ -53,6 +56,10 @@ jobs:
           --no-suggest
           --prefer-dist
           ${{ matrix.dep-version }}
+
+      - name: Install specific log version
+        run: composer update --no-interaction --prefer-dist psr/log:^${{ matrix.psr-log-version }}
+
 
       - name: PHPUnit
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require": {
         "php": "^7.2 || ^8.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0 || ^2.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.5",

--- a/src/Base.php
+++ b/src/Base.php
@@ -118,16 +118,16 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
 
     /**
      * @param LogLevel::* $level
-     * @param string $message
+     * @param string|\Stringable $message
      * @param array<string, mixed> $context
-     * @return void
      */
-    abstract protected function writeLog($level, $message, array $context = []);
+    abstract protected function writeLog($level, $message, array $context = []): void;
 
     /**
      * @param LogLevel::* $level
+     * @param array<string, mixed> $context
      */
-    public function log($level, $message, array $context = array())
+    public function log($level, $message, array $context = array()): void
     {
         // Directly access the array and values here rather than run through
         // getSyslogPriority to avoid the function calls in a potential hotspot
@@ -151,9 +151,10 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
     /**
      * Interpolates context values into the message placeholders.
      *
+     * @param string|\Stringable $message
      * @param array<string, mixed> $context
      */
-    protected function interpolate(string $message, array $context = array()): string
+    protected function interpolate($message, array $context = array()): string
     {
         // build a replacement array with braces around the context keys
         $replace = array();
@@ -163,16 +164,17 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
         }
 
         // interpolate replacement values into the message and return
-        return strtr($message, $replace);
+        return strtr((string)$message, $replace);
     }
 
     /**
      * Format log message
      *
      * @param LogLevel::* $level
+     * @param string|\Stringable $message
      * @param array<string, mixed> $context
      */
-    protected function formatMessage(string $level, string $message, array $context = array()): string
+    protected function formatMessage(string $level, $message, array $context = array()): string
     {
         $formatData = [
             'level' => $level,

--- a/src/ChainLogger.php
+++ b/src/ChainLogger.php
@@ -44,7 +44,7 @@ class ChainLogger extends Base
         $this->loggers[] = $logger;
     }
 
-    protected function writeLog($level, $message, array $context = array())
+    protected function writeLog($level, $message, array $context = array()): void
     {
         foreach ($this->loggers as $logger) {
             $logger->log($level, $message, $context);

--- a/src/File.php
+++ b/src/File.php
@@ -39,7 +39,7 @@ class File extends Base
         $this->fh = $fh;
     }
 
-    protected function writeLog($level, $message, array $context = array())
+    protected function writeLog($level, $message, array $context = array()): void
     {
         $line = $this->formatMessage($level, $message, $context);
 

--- a/src/Syslog.php
+++ b/src/Syslog.php
@@ -28,7 +28,7 @@ class Syslog extends Base
         }
     }
 
-    protected function writeLog($level, $message, array $context = array())
+    protected function writeLog($level, $message, array $context = array()): void
     {
         $syslogPriority = $this->getSyslogPriority($level);
         $syslogMessage = $this->interpolate($message, $context);


### PR DESCRIPTION
Declares compatibility with `psr/log:^2.0`, using the strategy suggested in the [PHP-FIG blog](https://www.php-fig.org/blog/2019/10/upgrading-psr-interfaces/). Return types are added where possible; parameters remain docblock-only.