### PR TITLE
Remove raising error for bad context.exception

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -199,8 +199,6 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
                 $exceptionMessage = (string) $context['exception'];
                 $message .= ' {' . self::EXCEPTION_INTREPOLATION_KEY . '}';
                 $context[self::EXCEPTION_INTREPOLATION_KEY] = $exceptionMessage;
-            } else {
-                trigger_error('context.exception is not a Throwable', E_USER_ERROR);
             }
         }
 


### PR DESCRIPTION
PSR-3 Section 1.3 states "A given value in the context MUST NOT throw an exception nor raise any php error, warning or notice."

In 2.4, when adding support for automatically rendering `exceptions`, this part of the spec was violated. This change corrects that.