### PR TITLE
Support psr/log:^3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,11 @@ jobs:
           - '7.4'
           - '8.0'
           - '8.1'
+          - '8.2'
         psr-log-version:
           - '1.0'
           - '2.0'
+          - '3.0'
         exclude:
           # psr/log:2.0 needs PHP8
           - php: '7.2'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,13 +31,19 @@ jobs:
           - '2.0'
           - '3.0'
         exclude:
-          # psr/log:2.0 needs PHP8
+          # psr/log:2.0 and 3.0 need PHP8
           - php: '7.2'
             psr-log-version: '2.0'
+          - php: '7.2'
+            psr-log-version: '3.0'
           - php: '7.3'
             psr-log-version: '2.0'
+          - php: '7.3'
+            psr-log-version: '3.0'
           - php: '7.4'
             psr-log-version: '2.0'
+          - php: '7.4'
+            psr-log-version: '3.0'
 
     steps:
       - name: Check out code

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require": {
         "php": "^7.2 || ^8.0",
-        "psr/log": "^1.0 || ^2.0"
+        "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.5",

--- a/tests/BaseTestTrait.php
+++ b/tests/BaseTestTrait.php
@@ -41,29 +41,26 @@ trait BaseTestTrait
     /**
      * @covers ::log
      * @dataProvider allLevels
+     * @param LogLevel::* $level
+     * @doesNotPerformAssertions
      */
     public function testSimpleWriteViaLog(string $level): void
     {
-        $this->assertNull(
-            // @phpstan-ignore-next-line
-            $this->getLogger()->log($level, 'Some message')
-        );
+        $this->getLogger()->log($level, 'Some message');
     }
 
     /**
      * @covers ::log
      * @dataProvider allLevels
      * @param LogLevel::* $level
+     * @doesNotPerformAssertions
      */
     public function testInterpolatedMessageAtAllLevels(string $level): void
     {
-        $this->assertNull(
-            // @phpstan-ignore-next-line
-            $this->getLogger()->log(
-                $level,
-                'Message with {format}',
-                ['format' => 'a placeholder']
-            )
+        $this->getLogger()->log(
+            $level,
+            'Message with {format}',
+            ['format' => 'a placeholder']
         );
     }
 


### PR DESCRIPTION
Widen the supported psr/log versions. Expands the test harness to ensure that tests are run against valid version combinations.