### PR TITLE
Improve type safety now supported by dropping psr/log@1

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -8,6 +8,7 @@ use BadMethodCallException;
 use DateTime;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LogLevel;
+use Stringable;
 use Throwable;
 
 /**
@@ -131,16 +132,15 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
 
     /**
      * @param LogLevel::* $level
-     * @param string|\Stringable $message
      * @param array<string, mixed> $context
      */
-    abstract protected function writeLog($level, $message, array $context = []): void;
+    abstract protected function writeLog($level, string|Stringable $message, array $context = []): void;
 
     /**
      * @param LogLevel::* $level
      * @param array<string, mixed> $context
      */
-    public function log($level, $message, array $context = array()): void
+    public function log($level, string|Stringable $message, array $context = array()): void
     {
         // Directly access the array and values here rather than run through
         // getSyslogPriority to avoid the function calls in a potential hotspot

--- a/src/ChainLogger.php
+++ b/src/ChainLogger.php
@@ -8,6 +8,7 @@ use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Stringable;
 
 /**
  * Handler for multiple loggers
@@ -44,7 +45,7 @@ class ChainLogger extends Base
         $this->loggers[] = $logger;
     }
 
-    protected function writeLog($level, $message, array $context = array()): void
+    protected function writeLog($level, string|Stringable $message, array $context = array()): void
     {
         foreach ($this->loggers as $logger) {
             $logger->log($level, $message, $context);

--- a/src/File.php
+++ b/src/File.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\SimpleLogger;
 
 use RuntimeException;
+use Stringable;
 
 /**
  * File logger
@@ -39,7 +40,7 @@ class File extends Base
         $this->fh = $fh;
     }
 
-    protected function writeLog($level, $message, array $context = array()): void
+    protected function writeLog($level, string|Stringable $message, array $context = array()): void
     {
         $line = $this->formatMessage($level, $message, $context);
 

--- a/src/Syslog.php
+++ b/src/Syslog.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Firehed\SimpleLogger;
 
-use RuntimeException;
 use Psr\Log\LogLevel;
+use Stringable;
 
 /**
  * Syslog Logger
@@ -23,12 +23,10 @@ class Syslog extends Base
      */
     public function __construct($ident = 'PHP', $facility = LOG_USER)
     {
-        if (! openlog($ident, LOG_ODELAY | LOG_PID, $facility)) {
-            throw new RuntimeException('Unable to connect to syslog.');
-        }
+        openlog($ident, LOG_ODELAY | LOG_PID, $facility);
     }
 
-    protected function writeLog($level, $message, array $context = array()): void
+    protected function writeLog($level, string|Stringable $message, array $context = array()): void
     {
         $syslogPriority = $this->getSyslogPriority($level);
         $syslogMessage = $this->interpolate($message, $context);


### PR DESCRIPTION
This updates `$message` types to `string|Stringable` per the updated type signature.