### PR TITLE
Remove dump() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,16 +75,6 @@ $logger->info('foobar');
 
 // Output to the file: "[2013-06-02 16:03:28] [error] Error at /Users/fred/Devel/libraries/simpleLogger/example.php at line 24"
 $logger->error('Error at {filename} at line {line}', array('filename' => __FILE__, 'line' => __LINE__));
-
-// Dump a variable
-$values = array(
-    'key' => 'value'
-);
-
-// Output: [2013-06-02 16:05:32] [debug] array (
-//  'key' => 'value',
-// )
-$logger->dump($values);
 ```
 
 ### Multiple loggers

--- a/src/Base.php
+++ b/src/Base.php
@@ -150,18 +150,6 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
     }
 
     /**
-     * Dump to log a variable (by example an array)
-     *
-     * @deprecated in v2.2.0, will be removed in v3.0.0
-     * @param mixed $variable
-     */
-    public function dump($variable): void
-    {
-        trigger_error(sprintf('%s is deprecated', __METHOD__), E_USER_DEPRECATED);
-        $this->log(LogLevel::DEBUG, var_export($variable, true));
-    }
-
-    /**
      * Interpolates context values into the message placeholders.
      *
      * @param string|\Stringable $message


### PR DESCRIPTION
This will be unsupported in v3, as documented.