### PR TITLE
Localize and tidy syslog utilities

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,8 @@
+# Upgrading
+
+## 3.x
+
+BC Breaks:
+
+- `dump()` has been removed without replacement
+- `getCurrentSyslogPriority()` has been removed without replacement

--- a/src/Base.php
+++ b/src/Base.php
@@ -19,6 +19,17 @@ use Throwable;
  */
 abstract class Base extends AbstractLogger implements ConfigurableLoggerInterface
 {
+    protected const LEVELS = [
+        LogLevel::EMERGENCY => \LOG_EMERG,
+        LogLevel::ALERT     => \LOG_ALERT,
+        LogLevel::CRITICAL  => \LOG_CRIT,
+        LogLevel::ERROR     => \LOG_ERR,
+        LogLevel::WARNING   => \LOG_WARNING,
+        LogLevel::NOTICE    => \LOG_NOTICE,
+        LogLevel::INFO      => \LOG_INFO,
+        LogLevel::DEBUG     => \LOG_DEBUG,
+    ];
+
     private const EXCEPTION_INTREPOLATION_KEY = 'simplelogger-internal-exception-render';
 
     /**

--- a/src/Base.php
+++ b/src/Base.php
@@ -19,17 +19,6 @@ use Throwable;
  */
 abstract class Base extends AbstractLogger implements ConfigurableLoggerInterface
 {
-    private const LEVELS = [
-        LogLevel::EMERGENCY => LOG_EMERG,
-        LogLevel::ALERT     => LOG_ALERT,
-        LogLevel::CRITICAL  => LOG_CRIT,
-        LogLevel::ERROR     => LOG_ERR,
-        LogLevel::WARNING   => LOG_WARNING,
-        LogLevel::NOTICE    => LOG_NOTICE,
-        LogLevel::INFO      => LOG_INFO,
-        LogLevel::DEBUG     => LOG_DEBUG,
-    ];
-
     private const EXCEPTION_INTREPOLATION_KEY = 'simplelogger-internal-exception-render';
 
     /**
@@ -111,23 +100,6 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
             throw new BadMethodCallException('Format string must contain %s');
         }
         $this->format = $format;
-    }
-
-    /**
-     * Get the syslog priority constant associated with the current level
-     */
-    public function getCurrentSyslogPriority(): int
-    {
-        return $this->getSyslogPriority($this->getLevel());
-    }
-
-    /**
-     * @param string $psrLevel PSR log level
-     * @return int LOG_ constant
-     */
-    protected function getSyslogPriority($psrLevel)
-    {
-        return self::LEVELS[$psrLevel];
     }
 
     /**

--- a/src/Syslog.php
+++ b/src/Syslog.php
@@ -15,6 +15,17 @@ use Stringable;
  */
 class Syslog extends Base
 {
+    private const LEVELS = [
+        LogLevel::EMERGENCY => LOG_EMERG,
+        LogLevel::ALERT     => LOG_ALERT,
+        LogLevel::CRITICAL  => LOG_CRIT,
+        LogLevel::ERROR     => LOG_ERR,
+        LogLevel::WARNING   => LOG_WARNING,
+        LogLevel::NOTICE    => LOG_NOTICE,
+        LogLevel::INFO      => LOG_INFO,
+        LogLevel::DEBUG     => LOG_DEBUG,
+    ];
+
     /**
      * Setup Syslog configuration
      *
@@ -32,5 +43,14 @@ class Syslog extends Base
         $syslogMessage = $this->interpolate($message, $context);
 
         syslog($syslogPriority, $syslogMessage);
+    }
+
+    /**
+     * @param string $psrLevel PSR log level
+     * @return int LOG_ constant
+     */
+    protected function getSyslogPriority($psrLevel)
+    {
+        return self::LEVELS[$psrLevel];
     }
 }

--- a/src/Syslog.php
+++ b/src/Syslog.php
@@ -9,17 +9,6 @@ use Stringable;
 
 class Syslog extends Base
 {
-    private const LEVELS = [
-        LogLevel::EMERGENCY => \LOG_EMERG,
-        LogLevel::ALERT     => \LOG_ALERT,
-        LogLevel::CRITICAL  => \LOG_CRIT,
-        LogLevel::ERROR     => \LOG_ERR,
-        LogLevel::WARNING   => \LOG_WARNING,
-        LogLevel::NOTICE    => \LOG_NOTICE,
-        LogLevel::INFO      => \LOG_INFO,
-        LogLevel::DEBUG     => \LOG_DEBUG,
-    ];
-
     /**
      * Setup Syslog configuration
      *

--- a/src/Syslog.php
+++ b/src/Syslog.php
@@ -7,37 +7,31 @@ namespace Firehed\SimpleLogger;
 use Psr\Log\LogLevel;
 use Stringable;
 
-/**
- * Syslog Logger
- *
- * @package SimpleLogger
- * @author  Frédéric Guillot
- */
 class Syslog extends Base
 {
     private const LEVELS = [
-        LogLevel::EMERGENCY => LOG_EMERG,
-        LogLevel::ALERT     => LOG_ALERT,
-        LogLevel::CRITICAL  => LOG_CRIT,
-        LogLevel::ERROR     => LOG_ERR,
-        LogLevel::WARNING   => LOG_WARNING,
-        LogLevel::NOTICE    => LOG_NOTICE,
-        LogLevel::INFO      => LOG_INFO,
-        LogLevel::DEBUG     => LOG_DEBUG,
+        LogLevel::EMERGENCY => \LOG_EMERG,
+        LogLevel::ALERT     => \LOG_ALERT,
+        LogLevel::CRITICAL  => \LOG_CRIT,
+        LogLevel::ERROR     => \LOG_ERR,
+        LogLevel::WARNING   => \LOG_WARNING,
+        LogLevel::NOTICE    => \LOG_NOTICE,
+        LogLevel::INFO      => \LOG_INFO,
+        LogLevel::DEBUG     => \LOG_DEBUG,
     ];
 
     /**
      * Setup Syslog configuration
      *
-     * @param  string $ident    Application name
+     * @param $ident Application name
      * @param  int    $facility See http://php.net/manual/en/function.openlog.php
      */
-    public function __construct($ident = 'PHP', $facility = LOG_USER)
+    public function __construct(string $ident = 'PHP', int $facility = LOG_USER)
     {
         openlog($ident, LOG_ODELAY | LOG_PID, $facility);
     }
 
-    protected function writeLog($level, string|Stringable $message, array $context = array()): void
+    protected function writeLog($level, string|Stringable $message, array $context = []): void
     {
         $syslogPriority = $this->getSyslogPriority($level);
         $syslogMessage = $this->interpolate($message, $context);
@@ -45,11 +39,7 @@ class Syslog extends Base
         syslog($syslogPriority, $syslogMessage);
     }
 
-    /**
-     * @param string $psrLevel PSR log level
-     * @return int LOG_ constant
-     */
-    protected function getSyslogPriority($psrLevel)
+    protected function getSyslogPriority(string $psrLevel): int
     {
         return self::LEVELS[$psrLevel];
     }

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -78,17 +78,6 @@ class BaseTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * @covers ::getCurrentSyslogPriority
-     * @covers ::setLevel
-     * @dataProvider syslogMap
-     */
-    public function testCorrectMappingOfPsrToSyslog(string $psrLevel, int $syslogLevel): void
-    {
-        $this->logger->setLevel($psrLevel);
-        $this->assertSame($syslogLevel, $this->logger->getCurrentSyslogPriority());
-    }
-
     /** @covers ::setFormat */
     public function testSetFormat(): void
     {


### PR DESCRIPTION
Moves the syslog-specific code into that logger, and remove a not-super-useful utility method. Adds an UPGRADING file to document the BC break.