### PR TITLE
Split formatting logic into dedicated tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,13 @@ The minimum log level is `LogLevel::DEBUG` by default.
 
 ### Formatting
 
-Starting in 2.1.0, custom message formatting can be configured with the `setFormat(string $format)` method.
+Starting in 3.0.0, message format customization can be accomplished in two ways:
+
+- Initialize `DefaultFormatter`, change its format with `setFormat(string $format)`, and pass it to your logger's constructor
+- Create a class that implements `FormatterInterface` and pass that to your logger's constructor
+
+#### `DefaultFormatter`
+
 The format provided MUST include `%s`, which is where the actual interpolated message will be placed.
 Formats MAY include `{date}` and/or `{level}`, which are placeholders for the timestamp and log level respectively.
 
@@ -134,15 +140,11 @@ The default format is `[{date}] [{level}] %s`, which will result in a log messag
 
 The date defaults to ATOM format, but can also be customized via `setDateFormat(string $format)` using any format string that `date()` accepts.
 
-Note: at this time, the `Syslog` logger does not use these formats.
+By default, this will ignore `exception` keys and perform normal message interpolation.
+By calling `setRenderExceptions(true)`, the equivalent of `(string) $context['exception']` will be appended to the log message if that key is set, so long as that value is `Throwable`.
 
-### Exception rendering
+#### Custom `FormatterInterface`
 
-Starting in 2.4.0, the loggers in this library have the ability to automatically render exceptions when passed to `$context` in the `exception` index.
-To avoid changing existing logging formats, this behavior must be explicitly adopted:
-
-```php
-$logger->setRenderExceptions(true);
-```
-
-If configured AND `$context['exception'] instanceof \Throwable`, then the exception will be cast to a string and appended to the end of the message.
+If you need deeper customization, such as log enrichment or more major format shifts, a custom `FormatterInterface` is the way to go.
+Doing so requires your own interpolation logic, as well as any other message enrichment or formatting.
+You'll be passed the same (unmodified) parameters as `LoggerInterface::log()` gets, and are responsible for transforming these values into a string.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,7 +2,25 @@
 
 ## 3.x
 
+Changes:
+
+- Formatting logic has been separated into `FormatterInterface`.
+
+- `DefaultFormatter`, whicih retains the previous log formatting logic, is now a bundled implementation.
+  If a logger is constructed without specifying a formatter, this one will be used.
+
+- `ChainLogger` no longer extends `Base`.
+  In unlikely situations, this could be a BC break.
+
+- `ChainLogger`'s `level` is now configurable only through a new `level` constructor parameter.
+
 BC Breaks:
 
-- `dump()` has been removed without replacement
-- `getCurrentSyslogPriority()` has been removed without replacement
+- Support for PHP before 8.1 (the oldest version with active support at time of writing) has been dropped.
+
+- `dump()` has been removed without replacement.
+
+- `getCurrentSyslogPriority()` has been removed without replacement.
+
+- `setFormat` and `setRenderExceptions` has been removed from `ConfigurableLoggerInterface` and all implementations.
+  The logic for these has been moved to the formatters.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -28,5 +28,8 @@ BC Breaks:
   The logic for these has been moved to the formatters.
   Only `setLevel` remains.
 
+- `Base`'s `writeLog` method has been replaced by `write`, which now receives the already-formatted message and no context.
+  This will only matter if you've directly extended `Base` rather than using one of the packaged implementations.
+
 - Minor: appending newlines to log message is done only in the file-based loggers instead of the root-level formatting tools.
   This should have no effect on most installations, but may subtly change results of `syslog` loggers.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,8 @@ Changes:
 
 - Formatting logic has been separated into `FormatterInterface`.
 
+- `Base` adds `public FormatterInterface $formatter`, which allows changing the formatter at runtime (though this is not recommended).
+
 - `DefaultFormatter`, whicih retains the previous log formatting logic, is now a bundled implementation.
   If a logger is constructed without specifying a formatter, this one will be used.
 
@@ -24,3 +26,4 @@ BC Breaks:
 
 - `setFormat` and `setRenderExceptions` has been removed from `ConfigurableLoggerInterface` and all implementations.
   The logic for these has been moved to the formatters.
+  Only `setLevel` remains.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -25,8 +25,8 @@ BC Breaks:
 - `getCurrentSyslogPriority()` has been removed without replacement.
 
 - `setFormat` and `setRenderExceptions` has been removed from `ConfigurableLoggerInterface` and all implementations.
-  The logic for these has been moved to the formatters.
   Only `setLevel` remains.
+  These methods now exist on `DefaultFormatter`, but not the broader `FormatterInterface`.
 
 - `Base`'s `writeLog` method has been replaced by `write`, which now receives the already-formatted message and no context.
   This will only matter if you've directly extended `Base` rather than using one of the packaged implementations.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -27,3 +27,6 @@ BC Breaks:
 - `setFormat` and `setRenderExceptions` has been removed from `ConfigurableLoggerInterface` and all implementations.
   The logic for these has been moved to the formatters.
   Only `setLevel` remains.
+
+- Minor: appending newlines to log message is done only in the file-based loggers instead of the root-level formatting tools.
+  This should have no effect on most installations, but may subtly change results of `syslog` loggers.

--- a/src/Base.php
+++ b/src/Base.php
@@ -53,9 +53,8 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
 
     /**
      * @param LogLevel::* $level
-     * @param array<string, mixed> $context
      */
-    abstract protected function writeLog($level, string|Stringable $message, array $context = []): void;
+    abstract protected function write(string $level, string $message): void;
 
     /**
      * @param LogLevel::* $level
@@ -66,7 +65,8 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
         // Directly access the array and values here rather than run through
         // getSyslogPriority to avoid the function calls in a potential hotspot
         if (self::LEVELS[$level] <= self::LEVELS[$this->level]) {
-            $this->writeLog($level, $message, $context);
+            $formatted = $this->formatter->format($level, $message, $context);
+            $this->write($level, $formatted);
         }
     }
 }

--- a/src/Base.php
+++ b/src/Base.php
@@ -42,7 +42,7 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
     /**
      * Set minimum log level
      *
-     * @param  string  $level
+     * @param LogLevel::* $level
      */
     public function setLevel(string $level): void
     {

--- a/src/Base.php
+++ b/src/Base.php
@@ -11,7 +11,7 @@ use Psr\Log\LogLevel;
 use Stringable;
 use Throwable;
 
-abstract class Base extends AbstractLogger implements ConfigurableLoggerInterface
+abstract class Base extends AbstractLogger
 {
     protected const LEVELS = [
         LogLevel::EMERGENCY => \LOG_EMERG,

--- a/src/Base.php
+++ b/src/Base.php
@@ -11,7 +11,7 @@ use Psr\Log\LogLevel;
 use Stringable;
 use Throwable;
 
-abstract class Base extends AbstractLogger
+abstract class Base extends AbstractLogger implements ConfigurableLoggerInterface
 {
     /**
      * Minimum log level for the logger

--- a/src/Base.php
+++ b/src/Base.php
@@ -11,12 +11,6 @@ use Psr\Log\LogLevel;
 use Stringable;
 use Throwable;
 
-/**
- * Base class for loggers
- *
- * @package SimpleLogger
- * @author  Frédéric Guillot
- */
 abstract class Base extends AbstractLogger implements ConfigurableLoggerInterface
 {
     protected const LEVELS = [

--- a/src/Base.php
+++ b/src/Base.php
@@ -30,36 +30,12 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
         LogLevel::DEBUG     => \LOG_DEBUG,
     ];
 
-    private const EXCEPTION_INTREPOLATION_KEY = 'simplelogger-internal-exception-render';
-
-    /**
-     * The date format to use in the {date} section of the log message. Stanard
-     * PHP date() formatting rules apply.
-     *
-     * @var string
-     */
-    private $dateFormat = DateTime::ATOM;
-
-    /**
-     * The complete log message format, including prefixes.
-     *
-     * @var string
-     */
-    private $format = '[{date}] [{level}] %s';
-
     /**
      * Minimum log level for the logger
      *
      * @var    string
      */
     private $level = LogLevel::DEBUG;
-
-    /**
-     * Whether to render exceptions in context automatically
-     *
-     * @var bool
-     */
-    private $renderExceptions = false;
 
     /**
      * Set minimum log level
@@ -83,37 +59,6 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
     }
 
     /**
-     * Set the date format. Any format string that date() accepts will work.
-     *
-     * @param string $format The format string
-     * @return void
-     */
-    public function setDateFormat(string $format)
-    {
-        $this->dateFormat = $format;
-    }
-
-    public function setRenderExceptions(bool $render): void
-    {
-        $this->renderExceptions = $render;
-    }
-
-    /**
-     * Set the message format. {date} and {level} will be substituted. '%s'
-     * must be present somewhere in the string, and the actual interpolated
-     * message being logged will be put there.
-     *
-     * @param string $format The format string
-     */
-    public function setFormat(string $format): void
-    {
-        if (false === strpos($format, '%s')) {
-            throw new BadMethodCallException('Format string must contain %s');
-        }
-        $this->format = $format;
-    }
-
-    /**
      * @param LogLevel::* $level
      * @param array<string, mixed> $context
      */
@@ -130,52 +75,5 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
         if (self::LEVELS[$level] <= self::LEVELS[$this->level]) {
             $this->writeLog($level, $message, $context);
         }
-    }
-
-    /**
-     * Interpolates context values into the message placeholders.
-     *
-     * @param string|\Stringable $message
-     * @param array<string, mixed> $context
-     */
-    protected function interpolate($message, array $context = array()): string
-    {
-        // build a replacement array with braces around the context keys
-        $replace = array();
-
-        foreach ($context as $key => $val) {
-            $replace['{' . $key . '}'] = $val;
-        }
-
-        // interpolate replacement values into the message and return
-        return strtr((string)$message, $replace);
-    }
-
-    /**
-     * Format log message
-     *
-     * @param LogLevel::* $level
-     * @param string|\Stringable $message
-     * @param array<string, mixed> $context
-     */
-    protected function formatMessage(string $level, $message, array $context = array()): string
-    {
-        $formatData = [
-            'level' => $level,
-            'date' => date($this->dateFormat),
-        ];
-
-        if ($this->renderExceptions && array_key_exists('exception', $context)) {
-            if ($context['exception'] instanceof Throwable) {
-                $exceptionMessage = (string) $context['exception'];
-                $message .= ' {' . self::EXCEPTION_INTREPOLATION_KEY . '}';
-                $context[self::EXCEPTION_INTREPOLATION_KEY] = $exceptionMessage;
-            }
-        }
-
-        return sprintf(
-            $this->interpolate($this->format, $formatData),
-            $this->interpolate($message, $context)
-        ) . PHP_EOL;
     }
 }

--- a/src/Base.php
+++ b/src/Base.php
@@ -33,9 +33,11 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
     /**
      * Minimum log level for the logger
      *
-     * @var    string
+     * @var LogLevel::* $level
      */
-    private $level = LogLevel::DEBUG;
+    private string $level = LogLevel::DEBUG;
+
+    public FormatterInterface $formatter;
 
     /**
      * Set minimum log level
@@ -49,11 +51,8 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
 
     /**
      * Get minimum log level
-     *
-     * @access public
-     * @return string
      */
-    public function getLevel()
+    public function getLevel(): string
     {
         return $this->level;
     }

--- a/src/Base.php
+++ b/src/Base.php
@@ -34,6 +34,8 @@ abstract class Base extends AbstractLogger implements ConfigurableLoggerInterfac
 
     /**
      * Get minimum log level
+     *
+     * @return LogLevel::*
      */
     public function getLevel(): string
     {

--- a/src/ConfigurableLoggerInterface.php
+++ b/src/ConfigurableLoggerInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Firehed\SimpleLogger;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 /**
  * This interface is only intended to be checked by user code. It is not
@@ -13,9 +14,8 @@ use Psr\Log\LoggerInterface;
  */
 interface ConfigurableLoggerInterface extends LoggerInterface
 {
-    public function setFormat(string $format): void;
-
+    /**
+     * @param LogLevel::* $level
+     */
     public function setLevel(string $level): void;
-
-    public function setRenderExceptions(bool $render): void;
 }

--- a/src/DefaultFormatter.php
+++ b/src/DefaultFormatter.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\SimpleLogger;
+
+use BadMethodCallException;
+use DateTimeInterface;
+use Stringable;
+use Throwable;
+
+class DefaultFormatter implements FormatterInterface
+{
+    private const EXCEPTION_INTREPOLATION_KEY = 'simplelogger-internal-exception-render';
+
+    /**
+     * The date format to use in the {date} section of the log message. Stanard
+     * PHP date() formatting rules apply.
+     */
+    private string $dateFormat = DateTimeInterface::ATOM;
+
+    /**
+     * The complete log message format, including prefixes.
+     *
+     * @var string
+     */
+    private $format = '[{date}] [{level}] %s';
+
+    /**
+     * Whether to render exceptions in context automatically
+     *
+     * @var bool
+     */
+    private $renderExceptions = false;
+
+    public function format(string $level, string|Stringable $message, array $context = []): string
+    {
+        $formatData = [
+            'level' => $level,
+            'date' => date($this->dateFormat),
+        ];
+
+        if ($this->renderExceptions && array_key_exists('exception', $context)) {
+            if ($context['exception'] instanceof Throwable) {
+                $exceptionMessage = (string) $context['exception'];
+                $message .= ' {' . self::EXCEPTION_INTREPOLATION_KEY . '}';
+                $context[self::EXCEPTION_INTREPOLATION_KEY] = $exceptionMessage;
+            }
+        }
+
+        return sprintf(
+            $this->interpolate($this->format, $formatData),
+            $this->interpolate($message, $context)
+        ) . PHP_EOL;
+    }
+
+    /**
+     * Set the date format. Any format string that date() accepts will work.
+     *
+     * @param string $format The format string
+     * @return void
+     */
+    public function setDateFormat(string $format)
+    {
+        $this->dateFormat = $format;
+    }
+
+    /**
+     * Set the message format. {date} and {level} will be substituted. '%s'
+     * must be present somewhere in the string, and the actual interpolated
+     * message being logged will be put there.
+     *
+     * @param string $format The format string
+     */
+    public function setFormat(string $format): void
+    {
+        if (false === strpos($format, '%s')) {
+            throw new BadMethodCallException('Format string must contain %s');
+        }
+        $this->format = $format;
+    }
+
+    public function setRenderExceptions(bool $render): void
+    {
+        $this->renderExceptions = $render;
+    }
+
+    /**
+     * Interpolates context values into the message placeholders.
+     *
+     * @param string|\Stringable $message
+     * @param array<string, mixed> $context
+     */
+    protected function interpolate($message, array $context = array()): string
+    {
+        // build a replacement array with braces around the context keys
+        $replace = array();
+
+        foreach ($context as $key => $val) {
+            $replace['{' . $key . '}'] = $val;
+        }
+
+        // interpolate replacement values into the message and return
+        return strtr((string)$message, $replace);
+    }
+}

--- a/src/DefaultFormatter.php
+++ b/src/DefaultFormatter.php
@@ -51,7 +51,7 @@ class DefaultFormatter implements FormatterInterface
         return sprintf(
             $this->interpolate($this->format, $formatData),
             $this->interpolate($message, $context)
-        ) . PHP_EOL;
+        );
     }
 
     /**

--- a/src/DefaultFormatter.php
+++ b/src/DefaultFormatter.php
@@ -21,17 +21,13 @@ class DefaultFormatter implements FormatterInterface
 
     /**
      * The complete log message format, including prefixes.
-     *
-     * @var string
      */
-    private $format = '[{date}] [{level}] %s';
+    private string $format = '[{date}] [{level}] %s';
 
     /**
      * Whether to render exceptions in context automatically
-     *
-     * @var bool
      */
-    private $renderExceptions = false;
+    private bool $renderExceptions = false;
 
     public function format(string $level, string|Stringable $message, array $context = []): string
     {

--- a/src/File.php
+++ b/src/File.php
@@ -37,7 +37,7 @@ class File extends Base
         if ($this->lock) {
             flock($this->fh, LOCK_EX);
         }
-        if (fwrite($this->fh, $message) === false) {
+        if (fwrite($this->fh, $message . \PHP_EOL) === false) {
             throw new RuntimeException('Unable to write to the log file.');
         }
         if ($this->lock) {

--- a/src/File.php
+++ b/src/File.php
@@ -21,7 +21,7 @@ class File extends Base
      *
      * @param string $filename Output file
      */
-    public function __construct($filename)
+    public function __construct(string $filename, FormatterInterface $formatter = new DefaultFormatter())
     {
         $this->lock = substr($filename, 0, 6) !== 'php://';
         $fh = fopen($filename, 'a');
@@ -29,9 +29,10 @@ class File extends Base
             throw new RuntimeException('Could not open log file');
         }
         $this->fh = $fh;
+        $this->formatter = $formatter;
     }
 
-    protected function write($level, string $message): void
+    protected function write(string $level, string $message): void
     {
         if ($this->lock) {
             flock($this->fh, LOCK_EX);

--- a/src/File.php
+++ b/src/File.php
@@ -7,12 +7,6 @@ namespace Firehed\SimpleLogger;
 use RuntimeException;
 use Stringable;
 
-/**
- * File logger
- *
- * @package SimpleLogger
- * @author  Frédéric Guillot
- */
 class File extends Base
 {
     /**
@@ -20,10 +14,7 @@ class File extends Base
      */
     protected $fh;
 
-    /**
-     * @var bool
-     */
-    private $lock = false;
+    private bool $lock = false;
 
     /**
      * Setup logger configuration
@@ -40,14 +31,12 @@ class File extends Base
         $this->fh = $fh;
     }
 
-    protected function writeLog($level, string|Stringable $message, array $context = array()): void
+    protected function write($level, string $message): void
     {
-        $line = $this->formatMessage($level, $message, $context);
-
         if ($this->lock) {
             flock($this->fh, LOCK_EX);
         }
-        if (fwrite($this->fh, $line) === false) {
+        if (fwrite($this->fh, $message) === false) {
             throw new RuntimeException('Unable to write to the log file.');
         }
         if ($this->lock) {

--- a/src/FormatterInterface.php
+++ b/src/FormatterInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Firehed\SimpleLogger;
 
+use Psr\Log\LogLevel;
 use Stringable;
 
 interface FormatterInterface

--- a/src/FormatterInterface.php
+++ b/src/FormatterInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\SimpleLogger;
+
+use Stringable;
+
+interface FormatterInterface
+{
+    /**
+     * @param LogLevel::* $level
+     * @param array<string, mixed> $context
+     */
+    public function format(string $level, string|Stringable $message, array $context = []): string;
+}

--- a/src/Stderr.php
+++ b/src/Stderr.php
@@ -12,8 +12,8 @@ namespace Firehed\SimpleLogger;
  */
 class Stderr extends File
 {
-    public function __construct()
+    public function __construct(FormatterInterface $formatter = new DefaultFormatter())
     {
-        parent::__construct('php://stderr');
+        parent::__construct('php://stderr', $formatter);
     }
 }

--- a/src/Stdout.php
+++ b/src/Stdout.php
@@ -12,8 +12,8 @@ namespace Firehed\SimpleLogger;
  */
 class Stdout extends File
 {
-    public function __construct()
+    public function __construct(FormatterInterface $formatter = new DefaultFormatter())
     {
-        parent::__construct('php://stdout');
+        parent::__construct('php://stdout', $formatter);
     }
 }

--- a/src/Syslog.php
+++ b/src/Syslog.php
@@ -26,8 +26,12 @@ class Syslog extends Base
      * @param $ident Application name
      * @param  int    $facility See http://php.net/manual/en/function.openlog.php
      */
-    public function __construct(string $ident = 'PHP', int $facility = LOG_USER)
-    {
+    public function __construct(
+        string $ident = 'PHP',
+        int $facility = LOG_USER,
+        FormatterInterface $formatter = new DefaultFormatter(),
+    ) {
+        $this->formatter = $formatter;
         openlog($ident, LOG_ODELAY | LOG_PID, $facility);
     }
 

--- a/src/Syslog.php
+++ b/src/Syslog.php
@@ -9,6 +9,17 @@ use Stringable;
 
 class Syslog extends Base
 {
+    protected const LEVELS = [
+        LogLevel::EMERGENCY => \LOG_EMERG,
+        LogLevel::ALERT     => \LOG_ALERT,
+        LogLevel::CRITICAL  => \LOG_CRIT,
+        LogLevel::ERROR     => \LOG_ERR,
+        LogLevel::WARNING   => \LOG_WARNING,
+        LogLevel::NOTICE    => \LOG_NOTICE,
+        LogLevel::INFO      => \LOG_INFO,
+        LogLevel::DEBUG     => \LOG_DEBUG,
+    ];
+
     /**
      * Setup Syslog configuration
      *
@@ -20,12 +31,11 @@ class Syslog extends Base
         openlog($ident, LOG_ODELAY | LOG_PID, $facility);
     }
 
-    protected function writeLog($level, string|Stringable $message, array $context = []): void
+    protected function write($level, string $message): void
     {
         $syslogPriority = $this->getSyslogPriority($level);
-        $syslogMessage = $this->interpolate($message, $context);
 
-        syslog($syslogPriority, $syslogMessage);
+        syslog($syslogPriority, $message);
     }
 
     protected function getSyslogPriority(string $psrLevel): int

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -25,7 +25,7 @@ class BaseTest extends \PHPUnit\Framework\TestCase
     {
         $this->logger = new class extends Base {
             public bool $wrote = false;
-            protected function writeLog($level, mixed $message, $context = []): void
+            protected function write(string $level, string $message): void
             {
                 $this->wrote = true;
             }
@@ -45,6 +45,7 @@ class BaseTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @param LL::* $atLevel
      * @param array<LL::*> $shouldLog Levels which should be logged
      */
     #[DataProvider('levelFiltering')]
@@ -67,24 +68,6 @@ class BaseTest extends \PHPUnit\Framework\TestCase
                 );
             }
         }
-    }
-
-    public function testSetFormat(): void
-    {
-        // @phpstan-ignore-next-line
-        $this->assertNull($this->logger->setFormat('[{level}] %s'));
-    }
-
-    public function testSetDateFormat(): void
-    {
-        // @phpstan-ignore-next-line
-        $this->assertNull($this->logger->setDateFormat('%Y-%m-%d'));
-    }
-
-    public function testSetFormatFailsIfPlaceholderIsMissing(): void
-    {
-        $this->expectException(LogicException::class);
-        $this->logger->setFormat('[{level}] oops no percent s');
     }
 
     /**

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -20,11 +20,17 @@ class BaseTest extends \PHPUnit\Framework\TestCase
     use LogLevelsTrait;
 
     private Base $logger;
+    private FormatterInterface&MockObject $formatter;
 
     public function setUp(): void
     {
-        $this->logger = new class extends Base {
+        $this->formatter = self::createMock(FormatterInterface::class);
+        $this->logger = new class ($this->formatter) extends Base {
             public bool $wrote = false;
+            public function __construct(FormatterInterface $formatter)
+            {
+                $this->formatter = $formatter;
+            }
             protected function write(string $level, string $message): void
             {
                 $this->wrote = true;

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -126,21 +126,4 @@ class BaseTest extends \PHPUnit\Framework\TestCase
             ],
         ];
     }
-
-    /**
-     * @return array<string|int>[]
-     */
-    public function syslogMap(): array
-    {
-        return [
-            [LL::EMERGENCY, LOG_EMERG],
-            [LL::ALERT, LOG_ALERT],
-            [LL::CRITICAL, LOG_CRIT],
-            [LL::ERROR, LOG_ERR],
-            [LL::WARNING, LOG_WARNING],
-            [LL::NOTICE, LOG_NOTICE],
-            [LL::INFO, LOG_INFO],
-            [LL::DEBUG, LOG_DEBUG],
-        ];
-    }
 }

--- a/tests/DefaultFormatterTest.php
+++ b/tests/DefaultFormatterTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\SimpleLogger;
+
+use LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+
+#[CoversClass(DefaultFormatter::class)]
+#[Small]
+class DefaultFormatterTest extends TestCase
+{
+    private DefaultFormatter $formatter;
+
+    public function setUp(): void
+    {
+        $this->formatter = new DefaultFormatter();
+    }
+
+    public function testSetFormat(): void
+    {
+        $this->formatter->setFormat('[{level}] %s');
+        $result = $this->formatter->format(LogLevel::DEBUG, 'message {a}', ['a' => 'b']);
+        self::assertSame('[debug] message b', $result);
+    }
+
+    #[DoesNotPerformAssertions]
+    public function testSetDateFormat(): void
+    {
+        $this->formatter->setDateFormat('%Y-%m-%d');
+        // Doesn't support clock. this can't be tested well :/
+    }
+
+    public function testSetFormatFailsIfPlaceholderIsMissing(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->formatter->setFormat('[{level}] oops no percent s');
+    }
+}

--- a/tests/DefaultFormatterTest.php
+++ b/tests/DefaultFormatterTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
+use RuntimeException;
 
 #[CoversClass(DefaultFormatter::class)]
 #[Small]
@@ -41,5 +42,15 @@ class DefaultFormatterTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->formatter->setFormat('[{level}] oops no percent s');
+    }
+
+    public function testExceptionRendering(): void
+    {
+        $this->formatter->setRenderExceptions(true);
+        $ex = new RuntimeException('test message');
+        $formatted = $this->formatter->format(LogLevel::ERROR, '', ['exception' => $ex]);
+        self::assertStringContainsString('[error]', $formatted);
+        self::assertStringContainsString('RuntimeException: test message', $formatted);
+        self::assertStringContainsString('Stack trace:', $formatted);
     }
 }


### PR DESCRIPTION
The default formatter is meant for basic human-readable logs. These days, there are a number of machine-optimized log formats that exist. This change intends to set a baseline of tooling in place that eases using them without runtime hacks.

Fixes #29, though in a very different way than originally planned.